### PR TITLE
Sending CTRL-D ends the game

### DIFF
--- a/src/main/java/GameException.java
+++ b/src/main/java/GameException.java
@@ -1,0 +1,5 @@
+public class GameException extends RuntimeException {
+    public GameException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/GameLoop.java
+++ b/src/main/java/GameLoop.java
@@ -8,10 +8,10 @@ public class GameLoop {
     }
 
     public void play() {
-        ui.render();
+        ui.render(game);
         while (!game.isOver()) {
             game.nextMove();
-            ui.render();
+            ui.render(game);
         }
         ui.message("Game Over");
     }

--- a/src/main/java/GameLoop.java
+++ b/src/main/java/GameLoop.java
@@ -9,6 +9,14 @@ public class GameLoop {
 
     public void play() {
         ui.render(game);
+        try {
+            loop();
+        } catch (GameException e) {
+            ui.message(e.getMessage());
+        }
+    }
+
+    private void loop() {
         while (!game.isOver()) {
             game.nextMove();
             ui.render(game);

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -1,4 +1,8 @@
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
 
 public class Main {
 
@@ -6,7 +10,14 @@ public class Main {
         BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
         BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(System.out));
 
-        new UI(reader, writer).start();
+        UI ui = new UI(reader, writer);
+
+        Player player1 = new Player(Marker.O, ui);
+        Player player2 = new Player(Marker.X, new ArtificialIntelligenceFinder(Marker.X));
+
+        Game game = new Game(player1, player2);
+
+        new GameLoop(game, ui).play();
     }
 
 }

--- a/src/main/java/UI.java
+++ b/src/main/java/UI.java
@@ -42,7 +42,7 @@ public class UI implements Finder {
         return input == null;
     }
 
-    private boolean quit() {
+    private void quit() {
         throw new GameException("Goodbye");
     }
 

--- a/src/main/java/UI.java
+++ b/src/main/java/UI.java
@@ -20,26 +20,38 @@ public class UI implements Finder {
     }
 
     private int getParsedUserInput() {
-        String input;
-        do input = read(); while (!validate(input));
-
-        if (input == null) throw new GameException("Goodbye");
-
-        return parse(input);
-    }
-
-    private boolean validate(String input) {
-        if (input == null) return true;
-        if (new IntegerRangeInputValidator(1, 9).isValid(input))
-            return true;
-        else {
-            message(input + " is not a valid space");
-            return false;
-        }
+        return parse(getUserInput());
     }
 
     private int parse(String input) {
         return Integer.parseInt(input);
+    }
+
+    private String getUserInput() {
+        String input;
+
+        do {
+            input = read();
+            if (isEndOfFile(input)) quit();
+        } while (!validate(input));
+
+        return input;
+    }
+
+    private boolean isEndOfFile(String input) {
+        return input == null;
+    }
+
+    private boolean quit() {
+        throw new GameException("Goodbye");
+    }
+
+    private boolean validate(String input) {
+        if (!new IntegerRangeInputValidator(1, 9).isValid(input)) {
+            message(input + " is not a valid space");
+            return false;
+        }
+        return true;
     }
 
     public void message(String contents) {

--- a/src/main/java/UI.java
+++ b/src/main/java/UI.java
@@ -7,17 +7,12 @@ public class UI implements Finder {
     private final String CURSOR_HOME = "\033[H";
     private final String NEW_LINE = "\n";
 
-    private Game game;
     private BufferedReader reader;
     private BufferedWriter writer;
 
     public UI(BufferedReader reader, BufferedWriter writer) {
         this.reader = reader;
         this.writer = writer;
-
-        Player player1 = new Player(Marker.O, this);
-        Player player2 = new Player(Marker.X, new ArtificialIntelligenceFinder(Marker.X));
-        this.game = new Game(player1, player2);
     }
 
     public Space getNextMove(Game game) {
@@ -48,11 +43,7 @@ public class UI implements Finder {
         write(contents + NEW_LINE);
     }
 
-    public void start() {
-        new GameLoop(game, this).play();
-    }
-
-    public void render() {
+    public void render(Game game) {
         clearScreen();
         write(new GamePresenter(game).present());
     }

--- a/src/main/java/UI.java
+++ b/src/main/java/UI.java
@@ -23,10 +23,13 @@ public class UI implements Finder {
         String input;
         do input = read(); while (!validate(input));
 
+        if (input == null) throw new GameException("Goodbye");
+
         return parse(input);
     }
 
     private boolean validate(String input) {
+        if (input == null) return true;
         if (new IntegerRangeInputValidator(1, 9).isValid(input))
             return true;
         else {

--- a/src/test/java/GameLoopTest.java
+++ b/src/test/java/GameLoopTest.java
@@ -15,6 +15,21 @@ public class GameLoopTest {
         assertEquals("render render render render Game Over", ui.log);
     }
 
+    @Test
+    public void itQuitsTheGameIfAGameExceptionIsThrown() {
+        Game game = new Game(new Player(null, null), new Player(null, null)) {
+            @Override
+            public void nextMove() {
+                throw new GameException("End of game");
+            }
+        };
+        FakeUI ui = new FakeUI();
+
+        new GameLoop(game, ui).play();
+
+        assertEquals("render End of game", ui.log);
+    }
+
     private class FakeGame extends Game {
         private int iterations;
 

--- a/src/test/java/GameLoopTest.java
+++ b/src/test/java/GameLoopTest.java
@@ -45,7 +45,7 @@ public class GameLoopTest {
         }
 
         @Override
-        public void render() {
+        public void render(Game game) {
             log += "render ";
         }
 

--- a/src/test/java/MainTest.java
+++ b/src/test/java/MainTest.java
@@ -1,6 +1,10 @@
 import org.junit.Test;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
 
 import static org.junit.Assert.assertTrue;
 

--- a/src/test/java/UITest.java
+++ b/src/test/java/UITest.java
@@ -12,16 +12,17 @@ import java.util.Deque;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 public class UITest {
     private FakeWriter writer;
     private FakeReader reader;
+    private Game game;
 
     @Before
     public void setUp() throws Exception {
         reader = new FakeReader();
         writer = new FakeWriter();
+        game = new Game(new Player(Marker.O, null), new Player(Marker.X, null));
     }
 
     @Test
@@ -30,7 +31,6 @@ public class UITest {
             .addLine("3");
 
         UI ui = new UI(reader, writer);
-        Game game = new Game(new Player(Marker.O, ui), new Player(Marker.X, ui));
 
         assertEquals(new Space(1, 0), ui.getNextMove(game));
         assertEquals(new Space(2, 0), ui.getNextMove(game));
@@ -42,7 +42,6 @@ public class UITest {
                 .addLine("1");
 
         UI ui = new UI(reader, writer);
-        Game game = new Game(new Player(Marker.O, ui), new Player(Marker.X, ui));
 
         assertEquals(new Space(0, 0), ui.getNextMove(game));
         assertThat(writer.getOutput(), CoreMatchers.containsString("asdf is not a valid space\n"));
@@ -54,7 +53,6 @@ public class UITest {
                 .addLine("2");
 
         UI ui = new UI(reader, writer);
-        Game game = new Game(new Player(Marker.O, ui), new Player(Marker.X, ui));
 
         assertEquals(new Space(1, 0), ui.getNextMove(game));
         assertThat(writer.getOutput(), CoreMatchers.containsString("1000 is not a valid space\n"));
@@ -62,9 +60,7 @@ public class UITest {
 
     @Test
     public void itWritesToOut() throws IOException {
-        reader.addLine("3");
-
-        new UI(reader, writer).render();
+        new UI(reader, writer).render(game);
 
         String expected =
                 "\u001B[2J\u001B[H" +
@@ -84,7 +80,6 @@ public class UITest {
             .addLine("9");
 
         UI ui = new UI(reader, writer);
-        Game game = new Game(new Player(Marker.O, ui), new Player(Marker.X, ui));
 
         assertEquals(new Space(0, 0), ui.getNextMove(game));
         assertEquals(new Space(2, 2), ui.getNextMove(game));
@@ -94,25 +89,6 @@ public class UITest {
     public void itCanSendAMessageToTheUser() {
         new UI(reader, writer).message("Hello world!");
         assertThat(writer.getOutput(), CoreMatchers.containsString("Hello world!\n"));
-    }
-
-    @Test
-    public void itStartsTheGame() throws IOException {
-        reader.addLine("1")
-            .addLine("2")
-            .addLine("4");
-
-        new UI(reader, writer).start();
-
-        String expectedBoard =
-                " O | O | X \n" +
-                "---+---+---\n" +
-                " O | X | 6 \n" +
-                "---+---+---\n" +
-                " X | 8 | 9 \n";
-
-        assertTrue(writer.getOutput().contains(expectedBoard));
-        assertTrue(writer.getOutput().contains("Game Over"));
     }
 
     private class FakeReader extends BufferedReader {

--- a/src/test/java/UITest.java
+++ b/src/test/java/UITest.java
@@ -7,8 +7,7 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
-import java.util.ArrayDeque;
-import java.util.Deque;
+import java.util.ArrayList;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -37,6 +36,22 @@ public class UITest {
     }
 
     @Test
+    public void itWritesToOut() throws IOException {
+        new UI(reader, writer).render(game);
+
+        String expected =
+                "\u001B[2J\u001B[H" +
+                        " 1 | 2 | 3 \n" +
+                        "---+---+---\n" +
+                        " 4 | 5 | 6 \n" +
+                        "---+---+---\n" +
+                        " 7 | 8 | 9 \n" +
+                        "\n";
+
+        assertEquals(expected, writer.getOutput());
+    }
+
+    @Test
     public void itCanHandleNonNumericCharacters() {
         reader.addLine("asdf")
                 .addLine("1");
@@ -58,20 +73,13 @@ public class UITest {
         assertThat(writer.getOutput(), CoreMatchers.containsString("1000 is not a valid space\n"));
     }
 
-    @Test
-    public void itWritesToOut() throws IOException {
-        new UI(reader, writer).render(game);
+    @Test(expected = GameException.class)
+    public void itThrowsAnExceptionIfEndOfFileIsReached() {
+        String EOF = null;
+        reader.addLine(EOF);
 
-        String expected =
-                "\u001B[2J\u001B[H" +
-                " 1 | 2 | 3 \n" +
-                "---+---+---\n" +
-                " 4 | 5 | 6 \n" +
-                "---+---+---\n" +
-                " 7 | 8 | 9 \n" +
-                "\n";
-
-        assertEquals(expected, writer.getOutput());
+        UI ui = new UI(reader, writer);
+        ui.getNextMove(game);
     }
 
     @Test
@@ -93,7 +101,7 @@ public class UITest {
 
     private class FakeReader extends BufferedReader {
 
-        private Deque<String> lines = new ArrayDeque<>();
+        private ArrayList<String> lines = new ArrayList<>();
 
         public FakeReader() {
             super(new Reader() {
@@ -112,7 +120,7 @@ public class UITest {
 
         @Override
         public String readLine() throws IOException {
-            return lines.remove();
+            return lines.remove(0);
         }
     }
 


### PR DESCRIPTION
Now when `CTRL-D` is sent, the UI class will quit the game. This is done by throwing an exception that works its way up the call stack until it reaches the game loop, which will catch it and quit the game.

While I was at it, I cleaned up the UI tests so that it uses fake buffered readers and writers. I also reorganized the GameLoop, Game, and UI relationship so that the UI no longer creates and configures a game, and it no longer instantiates and invokes the game loop.
